### PR TITLE
GPII-1286: Make a copy of testDef before we modify in buildTestFixture

### DIFF
--- a/gpii/node_modules/testing/src/CloudBased.js
+++ b/gpii/node_modules/testing/src/CloudBased.js
@@ -21,6 +21,7 @@ https://github.com/GPII/universal/blob/master/LICENSE.txt
 var fluid = require("infusion"),
     path = require("path"),
     gpii = fluid.registerNamespace("gpii"),
+    $ = fluid.registerNamespace("jQuery"),
     jqUnit = fluid.registerNamespace("jqUnit"),
     kettle = fluid.registerNamespace("kettle");
 
@@ -74,6 +75,7 @@ gpii.test.cloudBased.gpiiConfig = function (baseDir) {
 };
 
 gpii.test.cloudBased.buildTestFixture = function (testDef, baseDir) {
+    testDef = $.extend({}, testDef);
     testDef.expect = 1;
     testDef.sequence = fluid.makeArray(testDef.sequence);
     testDef.gradeNames = fluid.makeArray(testDef.gradeNames);


### PR DESCRIPTION
Both AcceptanceTests_easit4all.js and AcceptanceTests_easit4all_oauth2_filtering.js are using require("./AcceptanceTests_easit4all_testDefs.json"). This means that they will share the same datastructure as node will cache the object read from the json file.

AcceptanceTests_easit4all.js calls gpii.test.cloudBased.bootstrap(), which calls gpii.test.cloudBased.buildTestFixture(), which was modifying the passed in testDef.