### PR TITLE
GPII-572: Forget old subscriptions when disconnecting from the CAS

### DIFF
--- a/gpii/node_modules/contextManager/src/CASConnector.js
+++ b/gpii/node_modules/contextManager/src/CASConnector.js
@@ -75,9 +75,15 @@
                 });
             });
         });
+
         that.socket.on("error", function (a) {
             console.log("Error: " +JSON.stringify(a));
-        })
+        });
+
+        that.socket.on("disconnect", function (a) {
+            that.socket.removeAllListeners();
+            that.connectSocket();
+        });
     };
 
     /* Data will be input in the format:


### PR DESCRIPTION
Here's the fix. 
In order to reproduce the issue:

1.- Start the mockCAS script and the GPII - changes on noise will be received once at a time
2.- Stop/Start the mockCAS - changes on noise will be received once at a time, but we're getting 3 in a row