### PR TITLE
GPII-1230:  Keeping ProcessReporter code up to date.

### DIFF
--- a/gpii/node_modules/processReporter/README.md
+++ b/gpii/node_modules/processReporter/README.md
@@ -1,16 +1,12 @@
 Process Reporter
 ===
 
-<<<<<<< HEAD
-The Process Reporter uses the information stored in the `isRunning` block of a solutions registry entry to decide whether a solution is running.  For example, the `isRunning` block for the Linux screen reader Orca (the solution entry `org.gnome.orca`) is as follows:
-=======
 A fluid component that can be used to acquire information about the processes associated with a GPII solution.  In particular, it can determine the running status of a solution.
 
 ### Process Reporter API
 
 Given a solutions registry entry, the Process Reporter uses the information stored in the `isRunning` block to determine whether a solution has been launched and is currently running.  For example, the `isRunning` block for the Orca screen reader (the solution entry `org.gnome.orca`) is as
 follows:
-
 ```
 "isRunning": [
     {
@@ -29,7 +25,6 @@ The Process Reporter's invoker `handleIsRunning(entry)` uses the `type` property
 If the solutions registry entry does not have an `isRunning` block, then its run-state is not defined, and `handleIsRunning()` returns `undefined`.
 
 Most solutions run-state is based on a corresponding entry in the underlying OS's process or tasklist table.  For example, the Linux/GNOME solution `org.gnome.orca` is running if the `orca` screen reader process is running.  Similarly, on Windows, `org.nvda-project` is running if there is an `nvda` process in the tasklist.
->>>>>>> 701e0260df860ee1339fc8bb0b686ecf78c97c12
 
 Some solutions, however, are not strictly process-oriented.  An example is the GNOME Shell screen magnifier (solution `org.gnome.desktop.a11y.magnifier`).  The magnifier is not a separate process, but is built into GNOME Shell.  The magnifier is running if (1) the `gnome-shell` process is running and (2) the `org.gnome.desktop.a11y.applications screen-magnifier-enabled` GSetting is `true`.
 

--- a/gpii/node_modules/processReporter/index.js
+++ b/gpii/node_modules/processReporter/index.js
@@ -6,6 +6,5 @@ fluid.module.register("processReporter", __dirname, require);
 
 require("./src/processesBridge.js");
 require("./src/ProcessReporter.js");
-require("./src/ProcessesBridge.js");
 
 

--- a/gpii/node_modules/processReporter/src/ProcessReporter.js
+++ b/gpii/node_modules/processReporter/src/ProcessReporter.js
@@ -18,9 +18,6 @@ var fluid = fluid || require("infusion"),
 fluid.defaults("gpii.processReporter", {
     gradeNames: ["fluid.component"],
     components: {
-        platformReporter: {
-            type: "gpii.platformReporter.native"
-        },
         nameResolver: {
             type: "gpii.processReporter.nameResolver"
         }

--- a/gpii/node_modules/processReporter/src/processesBridge.js
+++ b/gpii/node_modules/processReporter/src/processesBridge.js
@@ -73,6 +73,17 @@ fluid.defaults("gpii.processes", {
             funcName: "gpii.processes.initProcInfoNotRunning",
             args: ["{that}", "{arguments}.0"]
                              // command name (string)
+        },
+        // Contesxt aware invokers.
+        getProcessList: {
+            funcName: "gpii.processes.get",
+            args: ["{that}.getPlaformProcesssList", "{arguments).0"]
+                                                     // optional string or numeric identifier of the process
+        },
+        getPlaformProcesssList : {
+            funcName: "gpii.processes.getPlaformProcesssList",
+            args: ["{arguments}.0"]
+                   // optional string or numeric identifier of the process
         }
     }
 });
@@ -248,3 +259,28 @@ gpii.processes.initProcInfoNotRunning = function (that, command) {
     });
 };
 
+/**
+ * Get the current list of processes or a single processes based on an OS native
+ * process inspector function.
+ *
+ * @param getPlaformProcesssList {Function} - OS native function for getting the
+ *                                            list of processes.
+ * @param identifeer {Number} or {String} - Optional process id number or
+ *                                          commadn name of the process.
+ * @return {Array} - Returns a list of process information objects.
+ */
+gpii.processes.get = function (getPlaformProcesssList, identifier) {
+    return getPlaformProcesssList(identifier);
+};
+
+/**
+ * Default function for the base 'gpii.processes' grade to return an empty list
+ * of process information objects.
+ *
+ * @param identifeer {Number} or {String} - Optional process id number or
+ *                                          command name of the process.
+ * @return {Array} - Returns an empty list.
+ */
+gpii.processes.getPlaformProcesssList = function (/* identifier */) {
+    return [];
+};

--- a/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
+++ b/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
@@ -72,12 +72,27 @@ fluid.defaults("gpii.tests.processes.mock", {
         mockFirefox: gpii.tests.processes.mockFirefox
     },
     invokers: {
-        getProcessList: {
-            funcName: "fluid.identity",
-            args: [gpii.tests.processes.mockProcessesList]
+        getPlaformProcesssList: {
+            funcName: "gpii.tests.getPlatformProcessList",
+            args: ["{arguments}.0"]
         }
     }
 });
+
+gpii.tests.getPlatformProcessList = function (identifier) {
+    var togo = gpii.tests.processes.mockProcessesList;
+    if (identifier) {
+        togo = fluid.find(
+            gpii.tests.processes.mockProcessesList,
+            function (procInfo) {
+                if (procInfo.pid === identifier) {
+                    return procInfo;
+                }
+            }, gpii.tests.processes.mockProcessesList
+        );
+    }
+    return togo;
+};
 
 /**
  * "Start" firefox if not alreday running.  Simulated by adding the mock firefox


### PR DESCRIPTION
Hey @kaspermarkus,

While looking into [GPII-1882](https://issues.gpii.net/browse/GPII-1882) (using the ProcessReporter in Acceptance testing), I noticed that your GPII-1230 branch was missing my latest changes to the ProcessReporter code (GPII-442).  For my own sake, I created a copy of your GPII-1230 branch and merged in the latest from my GPII-442 branch.  If it's of use to you, here it is in the form a pull request.

Feel free to ignore this if you had other ideas about how to proceed.
