### PR TITLE
GPII-1230: Use "isRunning" instead of "queryProcess".

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -929,7 +929,12 @@
                         "retryInterval": 1000
                     },
                     "registryName": "magnifierpane",
-                    "queryProcess": "Magnify.exe"
+                    "isRunning": [
+                        {
+                            "type": "gpii.processReporter.find",
+                            "command": "Magnify.exe"
+                        }
+                    ]
                 }
             }
         },
@@ -986,7 +991,12 @@
                 "type": "gpii.windows.enableRegisteredAT",
                 "options": {
                     "registryName": "osk",
-                    "queryProcess": "osk.exe"
+                    "isRunning": [
+                        {
+                            "type": "gpii.processReporter.find",
+                            "command": "osk.exe"
+                        }
+                    ]
                 }
             }
         },

--- a/tests/JournalIntegrationTests.js
+++ b/tests/JournalIntegrationTests.js
@@ -93,7 +93,12 @@ gpii.tests.journal.initialSettings = {
             },
             "options": {
                 "registryName": "magnifierpane",
-                "queryProcess": "Magnify.exe"
+                "isRunning": [
+                    {
+                        "type": "gpii.processReporter.find",
+                        "command": "Magnify.exe"
+                    }
+                ]
             }
         }]
     }
@@ -107,7 +112,12 @@ gpii.tests.journal.settingsAfterCrash = {
             },
             "options": {
                 "registryName": "magnifierpane",
-                "queryProcess": "Magnify.exe"
+                "isRunning": [
+                    {
+                        "type": "gpii.processReporter.find",
+                        "command": "Magnify.exe"
+                    }
+                ]
             }
         }]
     }

--- a/tests/platform/windows/windows-builtIn-testSpec.js
+++ b/tests/platform/windows/windows-builtIn-testSpec.js
@@ -42,7 +42,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -266,7 +271,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -288,7 +298,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -297,7 +312,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -479,7 +499,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -488,7 +513,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -510,7 +540,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -519,7 +554,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -701,7 +741,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -710,7 +755,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -732,7 +782,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -741,7 +796,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -923,7 +983,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -932,7 +997,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -954,7 +1024,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }],
                 "com.microsoft.windows.onscreenKeyboard": [{
@@ -963,7 +1038,12 @@ gpii.tests.windows.builtIn = [
                     },
                     "options": {
                         "registryName": "osk",
-                        "queryProcess": "osk.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "osk.exe"
+                            }
+                        ]
                     }
                 }]
             }
@@ -1038,7 +1118,12 @@ gpii.tests.windows.builtIn = [
                             retryInterval: 1000
                         },
                         "registryName": "magnifierpane",
-                        "queryProcess": "Magnify.exe"
+                        "isRunning": [
+                            {
+                                "type": "gpii.processReporter.find",
+                                "command": "Magnify.exe"
+                            }
+                        ]
                     }
                 }]
             }


### PR DESCRIPTION
I [commented](https://github.com/GPII/windows/pull/120#issuecomment-361300142) on @kaspermarkus original GPII-1230 pull request, and made a [branch/pull request](https://github.com/kaspermarkus/universal/pull/22) to show what I meant.  This pull request takes into account @kaspermarkus [GPII-1230-2](https://github.com/GPII/universal/pull/592) changes.
